### PR TITLE
Update Haskell.nix rev

### DIFF
--- a/nix/haskell-language-server.json
+++ b/nix/haskell-language-server.json
@@ -1,7 +1,9 @@
 {
   "url": "https://github.com/haskell/haskell-language-server.git",
-  "rev": "08dd104a0436a6ede9bff6d1a64eac3ec89e615f",
-  "date": "2020-05-08T11:41:23+01:00",
-  "sha256": "1r19yc4sn1mpydpbds15nq2y4mqwwcd12lclrn25gwa4qyb9liq5",
-  "fetchSubmodules": true
+  "rev": "6ef579894bf116b5a6f73957b5804e6f20d18165",
+  "date": "2020-05-12T22:41:03+01:00",
+  "sha256": "111p923xq02sqf2s0irmrgcpn5s88vm7v7cqkxaap1p5h74ai4zv",
+  "fetchSubmodules": true,
+  "deepClone": true,
+  "leaveDotGit": true
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,12 +1,8 @@
 { lib, config, sets, defaultSources, sources, ... }:
 let
   pkgs = config.nixpkgs.pkgs;
-  haskell-language-server-source = pkgs.fetchgit {
-    inherit (builtins.fromJSON (builtins.readFile ./haskell-language-server.json))
-      url sha256 fetchSubmodules
-      ;
-    deepClone = true; # Not too expensive for this repo; avoids some nasty errors.
-  };
+  haskell-language-server-source = pkgs.fetchgit
+    (builtins.removeAttrs (builtins.fromJSON (builtins.readFile ./haskell-language-server.json)) ["date"]);
   defaults = {
     configuration.packages.ghc.flags.ghci = lib.mkForce true;
     configuration.packages.ghci.flags.ghci = lib.mkForce true;
@@ -54,6 +50,15 @@ in
       defaults
       {
         stackYaml = haskell-language-server-source + "/stack-8.8.2.yaml";
+        # Fixups
+        configuration.nonReinstallablePkgs = [ "Cabal" ];
+      }
+    ];
+  packageSets.haskell-nix."ghc-8_8_3" =
+    lib.mkMerge [
+      defaults
+      {
+        stackYaml = haskell-language-server-source + "/stack-8.8.3.yaml";
         # Fixups
         configuration.nonReinstallablePkgs = [ "Cabal" ];
       }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -9,6 +9,13 @@ let
     configuration.reinstallableLibGhc = true;
     # This fixes a performance issue, probably https://gitlab.haskell.org/ghc/ghc/issues/15524
     configuration.packages.ghcide.configureFlags = [ "--enable-executable-dynamic" ];
+
+    # fixme: how to override a haskell.nix option?
+    configuration.packages.shake.src = lib.mkForce (builtins.fetchGit {
+      url = "https://github.com/wz1000/shake.git";
+      rev = "fb3859dca2e54d1bbb2c873e68ed225fa179fbef";
+      ref = "no-scheduler";
+    });
   };
 in
 {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,14 @@
 {
-    "hackage.nix": {
-        "branch": "master",
-        "description": "Automatically generated Nix expressions for Hackage",
-        "homepage": "",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "9416457638da51a476f26cb8ae478782e1ac096c",
-        "sha256": "1vaxrkbnhl2da1zw538h3hjljpw03acxv9l4f4gg5vv1a8jmdci8",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/9416457638da51a476f26cb8ae478782e1ac096c.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c9f056ed49f24d23040e17d53782d6c75b08553f",
-        "sha256": "1dxrx9i6xkl32r8vbnhgz46dra6nndy5mlar3dd90mphs8l0px6h",
+        "rev": "83c85a0f2200fa63ed6122d66317069e5c7da1da",
+        "sha256": "14r17js48fzamm6mq9kc6a78k72lkdg8c2l4ja4ihqlib2xi4917",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/c9f056ed49f24d23040e17d53782d6c75b08553f.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/83c85a0f2200fa63ed6122d66317069e5c7da1da.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -69,18 +57,6 @@
         "sha256": "1hdqmxwnsyvnn6idm3r9gckbmxajz11dclpjvpmb466s8w3bspm2",
         "type": "tarball",
         "url": "https://github.com/hercules-ci/project.nix/archive/db0eba4f3159c1eeae8b96362c2f338e3420ede5.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "stackage.nix": {
-        "branch": "master",
-        "description": "Automatically generated Nix expressions of Stackage snapshots",
-        "homepage": "",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "4024881c4ff974fc3b3bead1d1a733a6b1910cf1",
-        "sha256": "0x0da9glfwihdd8hzf6rzv7670sgmfdj2g7cys5p7rrmnf5whfcq",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/stackage.nix/archive/4024881c4ff974fc3b3bead1d1a733a6b1910cf1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/update
+++ b/update
@@ -1,9 +1,15 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash
 
-# When niv supports nixpkgs fetchgit, switch
+niv update
 
+# When niv supports nixpkgs fetchgit, switch
+# https://github.com/nmattia/niv/issues/58
+
+# Deep cloning is not too expensive for this repo and avoids some nasty errors.
 nix-prefetch-git \
   --fetch-submodules \
+  --deepClone \
+  --leave-dotGit \
   https://github.com/haskell/haskell-language-server.git \
   > nix/haskell-language-server.json


### PR DESCRIPTION
Hackage updates should be fixed in Haskell.nix now — https://github.com/input-output-hk/haskell.nix/commit/83c85a0f2200fa63ed6122d66317069e5c7da1da
